### PR TITLE
add support for script in language string

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ Output will be:
 "fr-CA"
 ```
 
-__Known issues__
-- Cannot cope with multi-part region codes, i.e. 'az-AZ-Cyrl' will be treated as 'az-AZ'
-
 __Running tests__
 ```
 npm install

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports.pick = function(supportedLanguages, acceptLanguage){
 
     var supported = supportedLanguages.map(function(support){
         var bits = support.split('-');
-        hasScript = bits.length === 3;
+        var hasScript = bits.length === 3;
 
         return {
             code: bits[0],
@@ -51,9 +51,9 @@ module.exports.pick = function(supportedLanguages, acceptLanguage){
             var supportedCode = supported[j].code.toLowerCase();
             var supportedScript = supported[j].script ? supported[j].script.toLowerCase() : supported[j].script;
             var supportedRegion = supported[j].region ? supported[j].region.toLowerCase() : supported[j].region;
-            if (langCode === supportedCode
-              && (!langScript || langScript === supportedScript)
-              && (!langRegion || langRegion === supportedRegion)) {
+            if (langCode === supportedCode &&
+              (!langScript || langScript === supportedScript) &&
+              (!langRegion || langRegion === supportedRegion)) {
                 return supportedLanguages[j];
             }
         }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var regex = /((([a-zA-Z]+(-[a-zA-Z]+)?)|\*)(;q=[0-1](\.[0-9]+)?)?)*/g;
+var regex = /((([a-zA-Z]+(-[a-zA-Z]+){0,2})|\*)(;q=[0-1](\.[0-9]+)?)?)*/g;
 
 module.exports.parse = function(al){
     var strings = (al || "").match(regex);
@@ -9,10 +9,12 @@ module.exports.parse = function(al){
 
         var bits = m.split(';');
         var ietf = bits[0].split('-');
+        var hasScript = ietf.length === 3;
 
         return {
             code: ietf[0],
-            region: ietf[1],
+            script: hasScript ? ietf[1] : null,
+            region: hasScript ? ietf[2] : ietf[1],
             quality: bits[1] ? parseFloat(bits[1].split('=')[1]) : 1.0
         };
     }).filter(function(r){
@@ -31,10 +33,12 @@ module.exports.pick = function(supportedLanguages, acceptLanguage){
 
     var supported = supportedLanguages.map(function(support){
         var bits = support.split('-');
+        hasScript = bits.length === 3;
 
         return {
             code: bits[0],
-            region: bits[1]
+            script: hasScript ? bits[1] : null,
+            region: hasScript ? bits[2] : bits[1]
         };
     });
 
@@ -42,10 +46,14 @@ module.exports.pick = function(supportedLanguages, acceptLanguage){
         var lang = accept[i];
         var langCode = lang.code.toLowerCase();
         var langRegion = lang.region ? lang.region.toLowerCase() : lang.region;
+        var langScript = lang.script ? lang.script.toLowerCase() : lang.script;
         for (var j = 0; j < supported.length; j++) {
             var supportedCode = supported[j].code.toLowerCase();
+            var supportedScript = supported[j].script ? supported[j].script.toLowerCase() : supported[j].script;
             var supportedRegion = supported[j].region ? supported[j].region.toLowerCase() : supported[j].region;
-            if (langCode === supportedCode && (!langRegion || langRegion === supportedRegion)) {
+            if (langCode === supportedCode
+              && (!langScript || langScript === supportedScript)
+              && (!langRegion || langRegion === supportedRegion)) {
                 return supportedLanguages[j];
             }
         }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -4,6 +4,11 @@ var should = require("should");
 
 var assertResult = function(expected, actual){
     actual.code.should.eql(expected.code);
+
+    if(actual.script || expected.script){
+        actual.script.should.eql(expected.script)
+    }
+
     if(actual.region || expected.region){
         actual.region.should.eql(expected.region)
     }
@@ -70,12 +75,29 @@ describe('accept-language#parse()', function(){
         assertResult({ code: 'en', quality: 0.4}, result[3]);
         assertResult({ code: 'fr', quality: 0.2}, result[4]);
     });
+
+    it('should correctly identify script', function(){
+        var result = parser.parse('zh-Hant-cn');
+        assertResult({ code: 'zh', script: 'Hant', region: 'cn', quality: 1.0}, result[0]);
+    });
+
+    it('should cope with script and a quality value', function(){
+        var result = parser.parse('zh-Hant-cn;q=1, zh-cn;q=0.6, zh;q=0.4');
+        assertResult({ code: 'zh', script: 'Hant', region: 'cn', quality: 1.0}, result[0]);
+        assertResult({ code: 'zh',                 region: 'cn', quality: 0.6}, result[1]);
+        assertResult({ code: 'zh',                               quality: 0.4}, result[2]);
+    });
 });
 
 describe('accept-language#pick()', function(){
     it('should pick a specific regional language', function(){
         var result = parser.pick(['en-US', 'fr-CA'], 'fr-CA,fr;q=0.2,en-US;q=0.6,en;q=0.4,*;q=0.5');
         assert.equal(result, 'fr-CA');
+    });
+
+    it('should pick a specific script (if specified)', function(){
+        var result = parser.pick(['zh-Hant-cn', 'zh-cn'], 'zh-Hant-cn,zh-cn;q=0.6,zh;q=0.4');
+        assert.equal(result, 'zh-Hant-cn');
     });
 
     it('should pick proper language regardless of casing', function(){


### PR DESCRIPTION
closes #8  (hopefully).

The regex is still quite permissive, insofar as it only uses the `-` character to delimit `language-script-region`  (the ISO implementation says that the script tag should be only 4 alpha characters).

I figured it was simpler to be permissive rather than strict. For reference, the list of script tag values is [here](http://unicode.org/iso15924/iso15924-codes.html)