### PR TITLE
Allow to use destructuring import with pick

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var isString = function(s){
     return typeof(s) === 'string';
 };
 
-module.exports.parse = function(al){
+function parse(al){
     var strings = (al || "").match(regex);
     return strings.map(function(m){
         if(!m){
@@ -28,13 +28,13 @@ module.exports.parse = function(al){
         });
 };
 
-module.exports.pick = function(supportedLanguages, acceptLanguage){
+function pick(supportedLanguages, acceptLanguage){
     if (!supportedLanguages || !supportedLanguages.length || !acceptLanguage) {
         return null;
     }
 
     if(isString(acceptLanguage)){
-        acceptLanguage = this.parse(acceptLanguage);
+        acceptLanguage = parse(acceptLanguage);
     }
 
     var supported = supportedLanguages.map(function(support){
@@ -67,3 +67,6 @@ module.exports.pick = function(supportedLanguages, acceptLanguage){
 
     return null;
 };
+
+module.exports.parse = parse;
+module.exports.pick = pick;

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function parse(al){
         }).sort(function(a, b){
             return b.quality - a.quality;
         });
-};
+}
 
 function pick(supportedLanguages, acceptLanguage){
     if (!supportedLanguages || !supportedLanguages.length || !acceptLanguage) {
@@ -66,7 +66,7 @@ function pick(supportedLanguages, acceptLanguage){
     }
 
     return null;
-};
+}
 
 module.exports.parse = parse;
 module.exports.pick = pick;


### PR DESCRIPTION
Hello! Thanks for the useful package!

This pull request vanishes `this` used in `pick` function in the package. `this` can be `undefined` when using ES6 destructuring import. For example:

```javascript
import { pick } from "accept-language-parser";

pick(["en", "ru"], "ru,en-US;q=0.8,en;q=0.6,uk;q=0.4"); // throws an error
```

While 

```javascript
import * as acceptLanguageParser from "accept-language-parser";

acceptLanguageParser.pick(["en", "ru"], "ru,en-US;q=0.8,en;q=0.6,uk;q=0.4"); // works fine
```

Thanks!