### PR TITLE
Add loose mode, fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Output will be:
 
 Output is always sorted in quality order from highest -> lowest. as per the http spec, omitting the quality value implies 1.0.
 
-#### parser.pick(supportedLangugagesArray, acceptLanguageHeader)
+#### parser.pick(supportedLangugagesArray, acceptLanguageHeader, options = {})
 
 *Alias*: parser.pick(supportedLanguagesArray, parsedAcceptLanguageHeader)
 
@@ -61,7 +61,22 @@ Output will be:
 "fr-CA"
 ```
 
-__Running tests__
+The `options` currently supports only `loose` option that allows partial matching on supported languages. For example:
+
+
+```
+parser.pick(['fr', 'en'], 'en-GB,en-US;q=0.9,fr-CA;q=0.7,en;q=0.8');
+```
+
+Would return:
+
+```
+"fr"
+```
+
+In loose mode the order of `supportedLanguagesArray` matters, as it is the first partially matching language that is returned. It means that if you want to pick more specific langauge first, you should list it first as well, for example: `['fr-CA', 'fr']`.
+
+### Running test
 ```
 npm install
 npm test

--- a/index.js
+++ b/index.js
@@ -28,7 +28,9 @@ function parse(al){
         });
 }
 
-function pick(supportedLanguages, acceptLanguage){
+function pick(supportedLanguages, acceptLanguage, options){
+    options = options || {};
+
     if (!supportedLanguages || !supportedLanguages.length || !acceptLanguage) {
         return null;
     }
@@ -58,8 +60,8 @@ function pick(supportedLanguages, acceptLanguage){
             var supportedScript = supported[j].script ? supported[j].script.toLowerCase() : supported[j].script;
             var supportedRegion = supported[j].region ? supported[j].region.toLowerCase() : supported[j].region;
             if (langCode === supportedCode &&
-              (!langScript || langScript === supportedScript) &&
-              (!langRegion || langRegion === supportedRegion)) {
+              (options.loose || !langScript || langScript === supportedScript) &&
+              (options.loose  || !langRegion || langRegion === supportedRegion)) {
                 return supportedLanguages[j];
             }
         }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -144,4 +144,19 @@ describe('accept-language#pick()', function(){
         var result = parser.pick(['en']);
         assert.equal(result, null);
     });
+
+    it('by default should be strict when selecting language', function(){
+        var result = parser.pick(['en', 'pl'], 'en-US;q=0.6');
+        assert.equal(result, null);
+    });
+
+    it('can select language loosely with an option', function(){
+        var result = parser.pick(['en', 'pl'], 'en-US;q=0.6', { loose: true });
+        assert.equal(result, 'en');
+    });
+
+    it('selects most matching language in loose mode', function(){
+        var result = parser.pick(['en-US', 'en', 'pl'], 'en-US;q=0.6', { loose: true });
+        assert.equal(result, 'en-US');
+    });
 });


### PR DESCRIPTION
Closes #24 

Loose mode allows for pick language that doesn't exactly match accept-language, e.g. it allows to select `en` when only `en-US` is present. It also allows to select more specific language if it is present first in the list.